### PR TITLE
appveyor for VS2015 and VS2017

### DIFF
--- a/CodeStats/CodeStats.csproj
+++ b/CodeStats/CodeStats.csproj
@@ -60,10 +60,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression.FileSystem" />

--- a/CodeStats/CodeStatsPackage.cs
+++ b/CodeStats/CodeStatsPackage.cs
@@ -1,21 +1,18 @@
-﻿using System;
+﻿using Kbg.NppPluginNET.PluginInfrastructure;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
+using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Windows.Forms;
-using System.Net;
-using Task = System.Threading.Tasks.Task;
-using System.Collections.Concurrent;
-using System.Collections;
 using System.Timers;
 using System.Web.Script.Serialization;
-using System.IO;
-using System.Collections.Generic;
-
-using Kbg.NppPluginNET.PluginInfrastructure;
-//using Newtonsoft.Json;
+using System.Windows.Forms;
+using Task = System.Threading.Tasks.Task;
 
 namespace CodeStats
 {

--- a/CodeStats/ConfigFile.cs
+++ b/CodeStats/ConfigFile.cs
@@ -1,5 +1,4 @@
 ﻿using Kbg.NppPluginNET.PluginInfrastructure;
-using System;
 using System.IO;
 using System.Text;
 

--- a/CodeStats/Constants.cs
+++ b/CodeStats/Constants.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Kbg.NppPluginNET.PluginInfrastructure;
+using System;
 using System.Net;
 using System.Text.RegularExpressions;
-using Kbg.NppPluginNET.PluginInfrastructure;
 
 namespace CodeStats
 {

--- a/CodeStats/PluginInfrastructure/DllExport/NppPlugin.DllExport.targets
+++ b/CodeStats/PluginInfrastructure/DllExport/NppPlugin.DllExport.targets
@@ -17,14 +17,7 @@
                    ProjectDirectory="$(MSBuildProjectDirectory)"
                    InputFileName="$(TargetPath)"
                    FrameworkPath="$(TargetedFrameworkDir);$(TargetFrameworkDirectory)"
-                   LibToolPath="$(DevEnvDir)\..\..\VC\bin"
                    LibToolDllPath="$(DevEnvDir)"
                    SdkPath="$(SDK40ToolsPath)"/>
- 
-    <Copy 
-        SourceFiles="$(TargetPath)" 
-        DestinationFolder="C:\Program Files (x86)\Notepad++\plugins\" 
-        Condition="Exists('C:\Program Files (x86)\Notepad++\plugins\')"
-        ContinueOnError="false" />
   </Target>
 </Project>

--- a/CodeStats/Properties/AssemblyInfo.cs
+++ b/CodeStats/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/CodeStats/Properties/Resources.Designer.cs
+++ b/CodeStats/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace CodeStats.Properties {
-    using System;
-    
-    
+namespace CodeStats.Properties
+{
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>

--- a/CodeStats/RunProcess.cs
+++ b/CodeStats/RunProcess.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,11 @@
-version: 4.0.2.{build}
-image: Visual Studio 2015
+version: 1.0.1.{build}
+image: Visual Studio 2017
 
 
 environment:
   matrix:
-  - PlatformToolset: v140
+    - PlatformToolset: VS15
+    - PlatformToolset: VS17
 
 platform:
     - x64
@@ -16,37 +17,39 @@ configuration:
 
 install:
     - if "%platform%"=="x64" set archi=amd64
-    - if "%platform%"=="Any CPU" set archi=x86
-    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+    - if "%platform%"=="x64" set platform_input=x64
 
-build:
-    parallel: true                  # enable MSBuild parallel builds
-    verbosity: minimal
+    - if "%platform%"=="Any CPU" set archi=x86
+    - if "%platform%"=="Any CPU" set platform_input=Any CPU
+
+    - if "%PlatformToolset%"=="VS15" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="VS17" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+
 
 build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"
-    - msbuild CodeStats.sln /m /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - msbuild CodeStats.sln /m /p:configuration="%configuration%" /p:platform="%platform_input%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 after_build:
     - cd "%APPVEYOR_BUILD_FOLDER%"\CodeStats
     - ps: >-
 
-        if ($env:PLATFORM -eq "x64" -and $env:CONFIGURATION -eq "Release") {
+        if ($env:PLATFORM_INPUT -eq "x64" -and $env:CONFIGURATION -eq "Release") {
             Push-AppveyorArtifact "bin\x64\$env:CONFIGURATION\CodeStats.dll" -FileName CodeStats.dll
         }
 
-        if ($env:PLATFORM -eq "Any CPU" -and $env:CONFIGURATION -eq "Release") {
+        if ($env:PLATFORM_INPUT -eq "Any CPU" -and $env:CONFIGURATION -eq "Release") {
             Push-AppveyorArtifact "bin\$env:CONFIGURATION\CodeStats.dll" -FileName CodeStats.dll
         }
 
-        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v140") {
-            if($env:PLATFORM -eq "x64"){
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "VS17") {
+            if($env:PLATFORM_INPUT -eq "x64"){
             $ZipFileName = "notepadpp-CodeStats_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
             Remove-Item bin\x64\$env:CONFIGURATION\*.exp
             Remove-Item bin\x64\$env:CONFIGURATION\*.lib
             7z a $ZipFileName bin\x64\$env:CONFIGURATION\*
             }
-            if($env:PLATFORM -eq "Any CPU"){
+            if($env:PLATFORM_INPUT -eq "Any CPU"){
             $ZipFileName = "notepadpp-CodeStats_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
             Remove-Item bin\$env:CONFIGURATION\*.exp
             Remove-Item bin\$env:CONFIGURATION\*.lib
@@ -68,5 +71,5 @@ deploy:
     force_update: true
     on:
         appveyor_repo_tag: true
-        PlatformToolset: v140
+        PlatformToolset: VS17
         configuration: Release


### PR DESCRIPTION
- updated appveyor.yml to support also VS2017
- removed unnecessary using and sort them by powertools

, see https://ci.appveyor.com/project/chcg/notepadpp-codestats/build/1.0.1.5