### PR TITLE
Add SAVE_LOG_IN_TEMP_INSTEAD_OF_PLUGIN_DIR preprocessor definition ...

### DIFF
--- a/CodeStats/Logger.cs
+++ b/CodeStats/Logger.cs
@@ -1,3 +1,5 @@
+// #define SAVE_LOG_IN_TEMP_INSTEAD_OF_PLUGIN_DIR
+
 using Kbg.NppPluginNET.PluginInfrastructure;
 using System;
 using System.IO;
@@ -66,10 +68,14 @@ namespace CodeStats
             //var configDir = Dependencies.AppDataDirectory;
             if (String.IsNullOrWhiteSpace(configDir))
             {
+#if SAVE_LOG_IN_TEMP_INSTEAD_OF_PLUGIN_DIR
+                configDir = System.Environment.GetEnvironmentVariable("TEMP");
+#else // BACKWARD COMPATIBLE
                 // get path of plugin configuration
                 StringBuilder sbIniFilePath = new StringBuilder(Win32.MAX_PATH);
                 Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_GETPLUGINSCONFIGDIR, Win32.MAX_PATH, sbIniFilePath);
                 configDir = sbIniFilePath.ToString();
+#endif
             }
             if (string.IsNullOrWhiteSpace(configDir)) return null;
 
@@ -83,10 +89,14 @@ namespace CodeStats
             //var configDir = Dependencies.AppDataDirectory;
             if (String.IsNullOrWhiteSpace(configDir))
             {
+#if SAVE_LOG_IN_TEMP_INSTEAD_OF_PLUGIN_DIR
+                configDir = System.Environment.GetEnvironmentVariable("TEMP");
+#else // BACKWARD COMPATIBLE
                 // get path of plugin configuration
                 StringBuilder sbIniFilePath = new StringBuilder(Win32.MAX_PATH);
                 Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_GETPLUGINSCONFIGDIR, Win32.MAX_PATH, sbIniFilePath);
                 configDir = sbIniFilePath.ToString();
+#endif
             }
             if (string.IsNullOrWhiteSpace(configDir)) return;
 


### PR DESCRIPTION
... and code, ***disabled by default*** in order to remain backward compatible for now... # legacy-bckcompat-isofunc-addonly-preproc-toggle-hotfix # prepared-hotfix-toggle

For the motivations behind this changeset, see:
-  https://github.com/p0358/notepadpp-CodeStats/issues/8
-  https://github.com/p0358/notepadpp-CodeStats/issues/8#issuecomment-486880337