### PR TITLE
Update plugin installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,11 @@ Code::Stats - Write code, level up, show off! A free stats tracking service for 
 Installation
 ------------
 
-1. Inside Notepad++ open the Plugin Manager (`Plugins` → `Plugin Manager` → `Show Plugin Manager`).
+1. Inside Notepad++ open the Plugin Manager (`Plugins` → `Plugin Admin`).
 
 2. Check the box next to `Code::Stats` in the list of plugins.
 
 3. Click the `Install` button.
-
-4. Restart Notepad++.
 
 3. Enter your [API token](https://codestats.net/my/machines), then press `enter`.
 


### PR DESCRIPTION
The installation process has changed.
Now the plugins panel contains Plugins Admin and notepad++ reboot is no longer needed.
![image](https://user-images.githubusercontent.com/7454137/58856668-9212af00-86a3-11e9-97b0-afa7c51fc007.png)